### PR TITLE
Add Hunt.io to Vendor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,15 @@ Feel free to [contribute](CONTRIBUTING.md).
         <td>2025-05-29</td>
     </tr>
     <tr>
+        <td>Hunt.io</td>
+        <td>ALL</td>
+        <td>Vendor</td>
+        <td>https://hunt.io/blog</td>
+        <td>N/A</td>
+        <td>None</td>
+        <td>2025-10-09</td>
+    </tr>
+    <tr>
         <td>DoublePulsar (Kevin Beaumont)</td>
         <td>All</td>
         <td>Analyst</td>


### PR DESCRIPTION
Added Hunt.io blog to the Vendor section of the Awesome Threat Intel Blogs list.