### PR TITLE
Add defend.network — daily AI-powered threat intelligence briefings

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,12 @@ Feel free to [contribute](CONTRIBUTING.md).
         <td><a href='https://app.obstracts.com/feeds/d7334860-baf1-5898-991a-caa68eb5580a' target='_blank'>Subscribe to Feed</a></td>
     </tr>
     <tr>
+        <td>defend.network</td>
+        <td>Vendor</td>
+        <td><a href='https://defend.network/briefings' target='_blank'>View blog</a></td>
+        <td><a href='https://defend.network/feed.xml' target='_blank'>Subscribe to Feed</a></td>
+    </tr>
+    <tr>
         <td>Doctor Web</td>
         <td>Vendor</td>
         <td><a href='https://news.drweb.com/all/?c=5' target='_blank'>View blog</a></td>

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ Feel free to [contribute](CONTRIBUTING.md).
         <td>defend.network</td>
         <td>Vendor</td>
         <td><a href='https://defend.network/briefings' target='_blank'>View blog</a></td>
-        <td><a href='https://defend.network/feed.xml' target='_blank'>Subscribe to Feed</a></td>
+        <td><a href='https://app.obstracts.com/feeds/9896fd2e-2cd7-538c-be15-f9ce860395f7' target='_blank'>Subscribe to Feed</a></td>
     </tr>
     <tr>
         <td>Doctor Web</td>


### PR DESCRIPTION
Add defend.network to Vendor section

defend.network publishes free daily AI-generated threat briefings and weekly vulnerability reports for security teams.

Each briefing is structured by threat type (16 categories), affected industry (13 categories), and severity level, with specific action checklists and remediation guidance.

Sources include CISA advisories, vendor bulletins, and leading cybersecurity publications including The Hacker News, BleepingComputer, Krebs on Security, Dark Reading, and The Record.

- Blog URL: https://defend.network/briefings
- RSS feed: https://defend.network/feed.xml
- Completely free, no signup required
- Daily publishing cadence

https://defend.network