### PR TITLE
Add CosmicBytez Labs (Analyst)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Feel free to [contribute](CONTRIBUTING.md).
         <td><a href='https://app.obstracts.com/feeds/c471de1b-328b-5e15-80d9-19e56af39136' target='_blank'>Subscribe to Feed</a></td>
     </tr>
     <tr>
+        <td>CosmicBytez Labs</td>
+        <td>Analyst</td>
+        <td><a href='https://labs.cosmicbytez.ca/' target='_blank'>View blog</a></td>
+        <td><a href='https://labs.cosmicbytez.ca/api/rss' target='_blank'>Subscribe to Feed</a></td>
+    </tr>
+    <tr>
         <td>Cyber Intelligence Insights</td>
         <td>Analyst</td>
         <td><a href='https://intelinsights.substack.com/' target='_blank'>View blog</a></td>


### PR DESCRIPTION
Adds CosmicBytez Labs to the Analyst section.

CosmicBytez Labs publishes daily IT and cybersecurity intelligence — news, CVE analyses, breach post-mortems, and step-by-step howtos (SentinelOne, Sysmon, Wazuh, etc). Independent / analyst-style coverage, not vendor-backed.

- Blog: https://labs.cosmicbytez.ca/
- RSS: https://labs.cosmicbytez.ca/api/rss
- Category: Analyst

I noticed the existing entries route Subscribe through `app.obstracts.com`. I've used the direct RSS URL above — happy to update to an obstracts proxy if you'd prefer; just point me at the right path.

Per CONTRIBUTING.md: inserted alphabetically between "Connof McGarr" and "Cyber Intelligence Insights" in the Analyst category.